### PR TITLE
add GHC 9.4 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        ghc: ['90', '92']
+        ghc: ['90', '92', '94']
         os: ['ubuntu-latest', 'macos-latest']
     runs-on: ${{ matrix.os }}
     name: Build with GHC ${{ matrix.ghc }} on ${{ matrix.os }}


### PR DESCRIPTION
This is expected to fail until further notice. :slightly_smiling_face: 

This is largely because there are many dependencies (libraries) that do not yet work with GHC 9.4 upstream.

How will we know when the world is ready for 9.4? By periodically bumping the Nix flake inputs (`nix flake update`) in this PR.